### PR TITLE
修改了一下PHP字符串拼接

### DIFF
--- a/YashiUser-Activation.php
+++ b/YashiUser-Activation.php
@@ -16,7 +16,7 @@
             <td align="right" width="50%">激活码*(text)：</td>
             <td><?php
                 $inacode = isset($_GET["acode"]) ? $_GET["acode"] : "";
-                echo "<input type=\"text\" name=\"acode\" id=\"acode\" value=\"".$inacode."\">";
+                echo '<input type="text" name="acode" id="acode" value="'.$inacode.'">';
             ?></td>
             
         </tr>
@@ -24,7 +24,7 @@
         <input type="hidden" name="echomode" id="echomode" value="html">
         <?php
           $backurl = isset($_GET["backurl"]) ? $_GET["backurl"] : "YashiUser-Login.php";
-          echo "<input type=\"hidden\" name=\"backurl\" id=\"backurl\" value=\"".$backurl."\">";
+          echo '<input type="hidden" name="backurl" id="backurl" value="'.$backurl.'">';
         ?>
             <td align="right"><input type="reset" name="reset" id="reset" value="取消"></td>
             <td><input type="button" name="submitbutton" id="submitbutton" value="激活用户" onclick="toVaild('php/yaloginActivationC.php')"></td>


### PR DESCRIPTION
雅诗姐用了变量内插的模式（""）就不用再用点连接符了～
可以考虑的修改方式有以下两种，

一是用静态字符串＋点连接符
echo '&lt;input type="text" name="acode" id="acode" value="'.$inacode.'">';

二是用变量内插（此时就不用点连接符了）
echo "&lt;input type=\"text\" name=\"acode\" id=\"acode\" value=\"$inacode\">";

嘛，其实也只是个人习惯～
感觉在这种有很多需要转义的地方用静态字符串＋点连接符看着清爽一些。此处在效率上的差别倒是完全没区别的。

(((o(*ﾟ▽ﾟ*)o)))